### PR TITLE
Update wholeBodyDynamics to use MulitpleAnalogSensor IMU

### DIFF
--- a/models/iRonCub-Mk1/iRonCub/robots/iRonCub-Mk1_Gazebo_v1/estimators/wholebodydynamics-external-iRonCub.xml
+++ b/models/iRonCub-Mk1/iRonCub/robots/iRonCub-Mk1_Gazebo_v1/estimators/wholebodydynamics-external-iRonCub.xml
@@ -16,6 +16,13 @@
         <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
         <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
         <param name="startWithZeroFTSensorOffsets">true</param> <!-- bypass using resetOffset of FT sensors in simulation -->
+        <param name="devicePeriodInSeconds">0.01</param>
+
+        <group name="HW_USE_MAS_IMU">
+            <param name="accelerometer">head_imu_acc_1x1</param>
+            <param name="gyroscope">head_imu_acc_1x1</param>
+        </group>
+
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/models/iRonCub-Mk1/iRonCub/robots/iRonCub-Mk1_Gazebo_v1/launch-wholebodydynamics-iRonCub.xml
+++ b/models/iRonCub-Mk1/iRonCub/robots/iRonCub-Mk1_Gazebo_v1/launch-wholebodydynamics-iRonCub.xml
@@ -60,6 +60,7 @@
     <device name="inertial" type="multipleanalogsensorsclient">
         <param name="remote"> /icubSim/head/inertials </param>
         <param name="local"> /wholeBodyDynamics/imu </param>
+        <param name="timeout"> 1.0 </param>
     </device>
 
     <!-- six axis force torque sensors -->

--- a/models/iRonCub-Mk1/iRonCub/robots/iRonCub-Mk1_Gazebo_v1/launch-wholebodydynamics-iRonCub.xml
+++ b/models/iRonCub-Mk1/iRonCub/robots/iRonCub-Mk1_Gazebo_v1/launch-wholebodydynamics-iRonCub.xml
@@ -57,8 +57,8 @@
     -->
 
     <!-- imu -->
-    <device name="inertial" type="genericSensorClient">
-        <param name="remote"> /icubSim/inertial </param>
+    <device name="inertial" type="multipleanalogsensorsclient">
+        <param name="remote"> /icubSim/head/inertials </param>
         <param name="local"> /wholeBodyDynamics/imu </param>
     </device>
 

--- a/models/iRonCub-Mk1_1/iRonCub/robots/iRonCub-Mk1_1_Gazebo_v1/estimators/wholebodydynamics-external-iRonCub.xml
+++ b/models/iRonCub-Mk1_1/iRonCub/robots/iRonCub-Mk1_1_Gazebo_v1/estimators/wholebodydynamics-external-iRonCub.xml
@@ -16,6 +16,13 @@
         <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
         <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
         <param name="startWithZeroFTSensorOffsets">true</param> <!-- bypass using resetOffset of FT sensors in simulation -->
+        <param name="devicePeriodInSeconds">0.01</param>
+
+        <group name="HW_USE_MAS_IMU">
+            <param name="accelerometer">head_imu_acc_1x1</param>
+            <param name="gyroscope">head_imu_acc_1x1</param>
+        </group>
+
 
         <!-- map between iDynTree links (identified by a name)
              and skinDynLib links (identified by their frame name, a BodyPart enum

--- a/models/iRonCub-Mk1_1/iRonCub/robots/iRonCub-Mk1_1_Gazebo_v1/launch-wholebodydynamics-iRonCub.xml
+++ b/models/iRonCub-Mk1_1/iRonCub/robots/iRonCub-Mk1_1_Gazebo_v1/launch-wholebodydynamics-iRonCub.xml
@@ -60,6 +60,7 @@
     <device name="inertial" type="multipleanalogsensorsclient">
         <param name="remote"> /icubSim/head/inertials </param>
         <param name="local"> /wholeBodyDynamics/imu </param>
+        <param name="timeout"> 1.0 </param>
     </device>
 
     <!-- six axis force torque sensors -->

--- a/models/iRonCub-Mk1_1/iRonCub/robots/iRonCub-Mk1_1_Gazebo_v1/launch-wholebodydynamics-iRonCub.xml
+++ b/models/iRonCub-Mk1_1/iRonCub/robots/iRonCub-Mk1_1_Gazebo_v1/launch-wholebodydynamics-iRonCub.xml
@@ -57,8 +57,8 @@
     -->
 
     <!-- imu -->
-    <device name="inertial" type="genericSensorClient">
-        <param name="remote"> /icubSim/inertial </param>
+    <device name="inertial" type="multipleanalogsensorsclient">
+        <param name="remote"> /icubSim/head/inertials </param>
         <param name="local"> /wholeBodyDynamics/imu </param>
     </device>
 


### PR DESCRIPTION
This should be more compatible with YARP `v3.8` because the device `inertial` is deprecated.