### PR TITLE
Add workaround to avoid installing an old ogre

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,10 @@ dependencies:
   - opencv
   - pyyaml=5
   - catkin_pkg
+  # Workaround for:
+  # * https://github.com/ami-iit/ironcub_mk1_software/issues/11#issuecomment-1802102145
+  # * https://github.com/conda-forge/openvino-feedstock/issues/52
+  - pugixml=1.13
   - pip:
     - git+https://github.com/ros/urdf_parser_py@31474b9baaf7c3845b40e5a9aa87d5900a2282c3
     - git+https://github.com/robotology/simmechanics-to-urdf@v0.4.1


### PR DESCRIPTION
Workaround for https://github.com/ami-iit/ironcub_mk1_software/issues/11 . Once the latest versions of libopenvino and ogre get consistent latest version (hopefully after https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5130 or after solving https://github.com/conda-forge/openvino-feedstock/issues/52), we can remove this.