### PR TITLE
Add matlab-whole-body-simulator dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - wb-toolbox 
   - whole-body-controllers 
   - whole-body-estimators 
+  - matlab-whole-body-simulator 
   - gazebo 
   - gazebo-yarp-plugins 
   - opencv


### PR DESCRIPTION
I added the dependency from [matlab-whole-body-simulator](https://github.com/ami-iit/matlab-whole-body-simulator) in the mamba installation file, since it is used in `momentum-based-flight-sim-no-gazebo`.